### PR TITLE
fix app_log.exception instead of error accept **kwargs

### DIFF
--- a/turbo/app.py
+++ b/turbo/app.py
@@ -189,7 +189,7 @@ class BaseBaseHandler(tornado.web.RequestHandler):
         except ResponseError as e:
             resp = self.init_resp(e.code, e.msg)
         except Exception as e:
-            app_log.exception(e, exc_info=True)
+            app_log.error(e, exc_info=True)
             resp = self.init_resp(1)
         else:
             resp = self.init_resp()


### PR DESCRIPTION
The version before 2.7.7 Logger.exception don't accept **kwargs.  But we can use Logger.error replace